### PR TITLE
fix: ESLintエラー修正（React Hooks違反・IconName型エラー）

### DIFF
--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -104,6 +104,14 @@ export const KanbanBoard = memo(function KanbanBoard({
     [],
   )
 
+  const resetDrag = useCallback(() => {
+    dragDataRef.current = null
+    setDraggingId(null)
+    setDropTargetId(null)
+    setDropMode(null)
+    setDropColumn(null)
+  }, [])
+
   const handleCardDrop = useCallback(
     (e: React.DragEvent, targetBookmarkId: string) => {
       e.preventDefault()
@@ -132,12 +140,12 @@ export const KanbanBoard = memo(function KanbanBoard({
       if (targetColumn === 'done' && onMarkRead) onMarkRead(data.bookmarkId)
       resetDrag()
     },
-    [kanbanColumns, onMoveItem, onMarkRead],
+    [kanbanColumns, onMoveItem, onMarkRead, resetDrag],
   )
 
   const handleCardDragEnd = useCallback(() => {
     resetDrag()
-  }, [])
+  }, [resetDrag])
 
   // --- 列への直接ドロップ（空列やカード外のエリア） ---
   const handleColumnDragOver = useCallback(
@@ -169,16 +177,8 @@ export const KanbanBoard = memo(function KanbanBoard({
       if (column === 'done' && onMarkRead) onMarkRead(data.bookmarkId)
       resetDrag()
     },
-    [kanbanColumns, onMoveItem, onMarkRead],
+    [kanbanColumns, onMoveItem, onMarkRead, resetDrag],
   )
-
-  function resetDrag() {
-    dragDataRef.current = null
-    setDraggingId(null)
-    setDropTargetId(null)
-    setDropMode(null)
-    setDropColumn(null)
-  }
 
   if (totalItems === 0) {
     return (

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -486,7 +486,7 @@ export function SettingsPanel({ settings, groups, t, onUpdateSettings, onClose, 
                   })
                 }}
               >
-                <Icon name="help" size={14} /> {t.restartTour}
+                <Icon name="help-circle" size={14} /> {t.restartTour}
               </button>
             </div>
 

--- a/src/hooks/useKanban.ts
+++ b/src/hooks/useKanban.ts
@@ -12,6 +12,12 @@ import { flattenGroups } from '../utils/bookmarks'
 
 export function useKanban(groups: SyncGridGroup[]) {
   const [kanbanState, setKanbanState] = useState<KanbanState>({ items: [] })
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [])
 
   // URL→SyncGridItem マップ（URL基準でブックマーク解決）
   const urlMap = useMemo(() => {
@@ -132,12 +138,11 @@ export function useKanban(groups: SyncGridGroup[]) {
 
   // 期限超過アイテム（done列以外）
   const overdueItems = useMemo(() => {
-    const now = Date.now()
     return kanbanState.items
       .filter((ki) => ki.dueDate && ki.dueDate < now && ki.column !== 'done')
       .map((ki) => urlMap.get(ki.url))
       .filter((item): item is SyncGridItem => !!item)
-  }, [kanbanState, urlMap])
+  }, [kanbanState, urlMap, now])
 
   const reloadKanban = useCallback(async () => {
     const state = await loadKanban()


### PR DESCRIPTION
## Summary

- `KanbanBoard.tsx`: `resetDrag` を `useCallback` に変換し宣言を使用箇所より前に移動、依存配列に追加（React Hooks `no-use-before-define` 違反を修正）
- `useKanban.ts`: `useMemo` 内の `Date.now()` をレンダー外に移動（`useState` + 60秒 `setInterval` で管理）
- `SettingsPanel.tsx`: `<Icon name="help">` → `<Icon name="help-circle">` に修正（TypeScript `IconName` 型エラーを解消）

## Test plan

- [ ] `npm run lint` がエラーなしで通ること
- [ ] `npm run build` が成功すること
- [ ] カンバンのドラッグ&ドロップが正常に動作すること
- [ ] 期限超過アイテムの検出が正常に動作すること
- [ ] 設定パネルのオンボーディングリセットボタンにアイコンが表示されること