### PR TITLE
fix: カンバン永続化・DnD・未分類フォルダ・削除経路の徹底改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Thumbs.db
 
 # Logs
 *.log
+
+# Vite dev キャッシュ
+.vite/

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,10 +12,6 @@
     "storage",
     "favicon"
   ],
-  "host_permissions": [
-    "https://api.openai.com/*",
-    "https://generativelanguage.googleapis.com/*"
-  ],
   "optional_host_permissions": [
     "https://*/*",
     "http://*/*"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,9 @@ import {
   getRootId,
   flattenGroups,
   countAll,
+  findGroupById,
 } from './utils/bookmarks'
+import { addToTrash } from './utils/trash'
 import type { SyncGridItem, SyncGridGroup, LayoutMode, SortMode } from './types'
 import { isComposing, matchesBinding } from './utils/keyboard'
 import { pullKanbanFromSync } from './utils/localSync'
@@ -311,68 +313,125 @@ export default function App() {
   const handleCreateGroup = useCallback(async () => {
     const name = newGroupName.trim()
     if (!name) { setCreatingGroup(false); return }
-    await createGroup(name, await getRootId())
-    setCreatingGroup(false)
-    setNewGroupName('')
-    await refresh()
-  }, [newGroupName, refresh])
+    try {
+      await createGroup(name, await getRootId())
+      setCreatingGroup(false)
+      setNewGroupName('')
+      await refresh()
+    } catch {
+      showToast(t.actionFailed, 'error')
+    }
+  }, [newGroupName, refresh, showToast, t])
 
   const handleCreateSubfolder = useCallback(async () => {
     const name = newGroupName.trim()
     if (!name) { setCreatingGroup(false); return }
-    await createGroup(name, nav.currentFolder?.id || (await getRootId()))
-    setCreatingGroup(false)
-    setNewGroupName('')
-    await refresh()
-  }, [newGroupName, nav.currentFolder, refresh])
+    try {
+      await createGroup(name, nav.currentFolder?.id || (await getRootId()))
+      setCreatingGroup(false)
+      setNewGroupName('')
+      await refresh()
+    } catch {
+      showToast(t.actionFailed, 'error')
+    }
+  }, [newGroupName, nav.currentFolder, refresh, showToast, t])
 
   const handleAddBookmark = useCallback(
     async (url: string, title: string) => {
       if (!nav.currentFolder) return
-      await addBookmark(nav.currentFolder.id, title, url)
-      setShowAddForm(false)
-      await refresh()
+      try {
+        await addBookmark(nav.currentFolder.id, title, url)
+        setShowAddForm(false)
+        await refresh()
+      } catch {
+        showToast(t.actionFailed, 'error')
+      }
     },
-    [nav.currentFolder, refresh],
+    [nav.currentFolder, refresh, showToast, t],
   )
 
   const handleSaveBookmark = useCallback(
     async (id: string, title: string, url: string, tags: string[]) => {
-      await updateBookmark(id, { title, url })
-      await handleSaveMeta(id, tags)
-      setEditItem(null)
-      await refresh()
+      try {
+        await updateBookmark(id, { title, url })
+        await handleSaveMeta(id, tags)
+        setEditItem(null)
+        await refresh()
+      } catch {
+        showToast(t.actionFailed, 'error')
+      }
     },
-    [refresh, handleSaveMeta],
+    [refresh, handleSaveMeta, showToast, t],
   )
 
-  const handleDeleteBookmark = useCallback(
-    async (id: string) => {
-      await removeBookmark(id)
-      setEditItem(null)
-      await refresh()
+  // ブックマークをゴミ箱経由で削除する共通処理（確認ダイアログ＋トースト＋復元可能）
+  const requestDeleteBookmark = useCallback(
+    (item: SyncGridItem) => {
+      setConfirmDialog({
+        message: t.confirmDeleteBookmark(item.title || item.url),
+        confirmLabel: t.delete,
+        onConfirm: async () => {
+          setConfirmDialog(null)
+          try {
+            const parentTitle = findGroupById(groups, item.parentId)?.title ?? ''
+            await addToTrash({
+              id: `trash_${Date.now()}_${item.id}`,
+              title: item.title,
+              url: item.url,
+              parentId: item.parentId,
+              parentTitle,
+              deletedAt: Date.now(),
+            })
+            await removeBookmark(item.id)
+            setEditItem(null)
+            showToast(t.bookmarkDeleted, 'success')
+            await refresh()
+          } catch {
+            showToast(t.actionFailed, 'error')
+          }
+        },
+      })
     },
-    [refresh],
+    [t, groups, refresh, showToast],
+  )
+
+  // 編集モーダルからの削除（id受け取り→itemを解決）
+  const handleDeleteBookmark = useCallback(
+    (id: string) => {
+      const item = editItem?.id === id
+        ? editItem
+        : flattenGroups(groups).flatMap((g) => g.items).find((i) => i.id === id)
+      if (item) requestDeleteBookmark(item)
+    },
+    [editItem, groups, requestDeleteBookmark],
   )
 
   const handleFolderRename = useCallback(
     async (id: string, name: string) => {
       const trimmed = name.trim()
-      if (trimmed) await renameGroup(id, trimmed)
-      setRenamingFolderId(null)
-      await refresh()
+      try {
+        if (trimmed) await renameGroup(id, trimmed)
+        setRenamingFolderId(null)
+        await refresh()
+      } catch {
+        showToast(t.actionFailed, 'error')
+      }
     },
-    [refresh],
+    [refresh, showToast, t],
   )
 
   const handleRenameSubmit = useCallback(async () => {
     if (!renamingTabId) return
     const name = renameValue.trim()
-    if (name) await renameGroup(renamingTabId, name)
-    setRenamingTabId(null)
-    setRenameValue('')
-    await refresh()
-  }, [renamingTabId, renameValue, refresh])
+    try {
+      if (name) await renameGroup(renamingTabId, name)
+      setRenamingTabId(null)
+      setRenameValue('')
+      await refresh()
+    } catch {
+      showToast(t.actionFailed, 'error')
+    }
+  }, [renamingTabId, renameValue, refresh, showToast, t])
 
   // --- Context menus ---
   const handleBookmarkContext = useCallback(
@@ -392,11 +451,11 @@ export default function App() {
             ? { label: t.removeFromKanban, icon: 'columns', shortcut: 'K', action: () => removeFromKanban(item.id) }
             : { label: t.addToKanban, icon: 'columns', shortcut: 'K', action: () => addToKanban(item.id) },
           { label: '---', action: () => {} },
-          { label: t.delete, icon: 'trash', danger: true, action: async () => { await removeBookmark(item.id); refresh() } },
+          { label: t.delete, icon: 'trash', danger: true, action: () => requestDeleteBookmark(item) },
         ],
       })
     },
-    [refresh, t, handleSetStatus, isInKanban, addToKanban, removeFromKanban],
+    [t, handleSetStatus, isInKanban, addToKanban, removeFromKanban, requestDeleteBookmark],
   )
 
   // カンバン内ブックマークのコンテキストメニュー

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { HelpPanel } from './components/HelpPanel'
 import { KanbanBoard } from './components/KanbanBoard'
 import { ToastContainer } from './components/Toast'
 import { useToast } from './hooks/useToast'
+import { useFocusTrap } from './hooks/useFocusTrap'
 import {
   addBookmark,
   removeBookmark,
@@ -58,6 +59,9 @@ export default function App() {
 
   // --- Toast (操作の成否通知) ---
   const { toasts, showToast, dismiss: dismissToast } = useToast()
+
+  // 期限設定モーダル用フォーカストラップ
+  const dueDateTrapRef = useFocusTrap<HTMLDivElement>()
 
   // --- Extracted hooks ---
   const { allMeta, handleSetStatus, handleSaveMeta } = useMetadata(groups)
@@ -878,7 +882,7 @@ export default function App() {
       {showHelp && (<HelpPanel onClose={() => setShowHelp(false)} t={t} />)}
       {dueDateTarget && (
         <div className="sg-modal-overlay" onClick={() => setDueDateTarget(null)}>
-          <div className="sg-modal" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => { if (e.key === 'Escape') setDueDateTarget(null) }}>
+          <div ref={dueDateTrapRef} className="sg-modal" role="dialog" aria-modal="true" aria-label={t.kanbanSetDueDate} onClick={(e) => e.stopPropagation()} onKeyDown={(e) => { if (e.key === 'Escape') setDueDateTarget(null) }}>
             <div className="sg-modal__header">
               <span className="sg-modal__title">{t.kanbanSetDueDate}</span>
               <button className="sg-modal__close" onClick={() => setDueDateTarget(null)} aria-label={t.close}><Icon name="close" size={12} /></button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,8 @@ import { OnboardingTour } from './components/OnboardingTour'
 import { KeyboardShortcutsPanel } from './components/KeyboardShortcutsPanel'
 import { HelpPanel } from './components/HelpPanel'
 import { KanbanBoard } from './components/KanbanBoard'
+import { ToastContainer } from './components/Toast'
+import { useToast } from './hooks/useToast'
 import {
   addBookmark,
   removeBookmark,
@@ -43,11 +45,17 @@ import { pullKanbanFromSync } from './utils/localSync'
 
 import './styles/global.css'
 
+/** タブ直下の未分類ブックマークをまとめる仮想フォルダのID */
+const UNCATEGORIZED_ID = '__uncategorized_virtual__'
+
 export default function App() {
   const { groups, loading, refresh } = useBookmarks()
   const { settings, updateSettings, loaded } = useSettings()
   useTheme(settings.theme)
   const t = useI18n(settings.locale)
+
+  // --- Toast (操作の成否通知) ---
+  const { toasts, showToast, dismiss: dismissToast } = useToast()
 
   // --- Extracted hooks ---
   const { allMeta, handleSetStatus, handleSaveMeta } = useMetadata(groups)
@@ -58,7 +66,23 @@ export default function App() {
     allTagsInFolder, applyFiltersAndSort,
   } = useFiltering(groups, nav.currentFolder, allMeta, settings.sort)
   const { collapsedIds, toggleCollapse, expandAll, collapseAll } = useCollapse()
-  const { kanbanColumns, kanbanItemCount, isInKanban, addToKanban, removeFromKanban, moveItem: moveKanbanItem, setDueDate, dueDates, overdueItems, reloadKanban } = useKanban(groups)
+  const handleKanbanError = useCallback(() => showToast(t.kanbanSaveError, 'error'), [showToast, t])
+  const { kanbanColumns, kanbanItemCount, isInKanban, addToKanban, removeFromKanban, moveItem: moveKanbanItem, setDueDate, dueDates, overdueItems, reloadKanban } = useKanban(groups, { onError: handleKanbanError })
+
+  // タブ直下の未分類ブックマークを折りたためる仮想フォルダにまとめる。
+  // サブフォルダが存在する場合のみ（フラットなフォルダは素のグリッドのまま）。
+  const uncategorizedGroup = useMemo<SyncGridGroup | null>(() => {
+    const folder = nav.currentFolder
+    if (!folder || folder.items.length === 0 || folder.children.length === 0) return null
+    return {
+      id: UNCATEGORIZED_ID,
+      title: t.uncategorized,
+      items: folder.items,
+      children: [],
+      parentId: folder.id,
+      depth: 0,
+    }
+  }, [nav.currentFolder, t])
 
   // 全フォルダIDを再帰収集（一括折りたたみ用）
   const allFolderIds = useMemo(() => {
@@ -69,8 +93,9 @@ export default function App() {
       for (const child of group.children) collect(child)
     }
     for (const child of nav.currentFolder.children) collect(child)
+    if (uncategorizedGroup) ids.push(UNCATEGORIZED_ID)
     return ids
-  }, [nav.currentFolder])
+  }, [nav.currentFolder, uncategorizedGroup])
 
   // --- 積読サジェスト ---
   const STALE_DAYS = 7
@@ -383,9 +408,9 @@ export default function App() {
           { label: t.openNewTab, icon: 'link', shortcut: 'O', action: () => { window.open(item.url, '_blank'); handleSetStatus(item.id, 'read') } },
           { label: t.edit, icon: 'edit', shortcut: 'E', action: () => setEditItem(item) },
           { label: '---', action: () => {} },
-          { label: t.kanbanTodo, icon: 'columns', action: () => moveKanbanItem(item.id, 'todo', 0) },
-          { label: t.kanbanDoing, icon: 'columns', action: () => moveKanbanItem(item.id, 'doing', 0) },
-          { label: t.kanbanDone, icon: 'columns', action: () => { moveKanbanItem(item.id, 'done', 0); handleSetStatus(item.id, 'read') } },
+          { label: t.kanbanTodo, icon: 'columns', action: () => moveKanbanItem(item.id, 'todo', null) },
+          { label: t.kanbanDoing, icon: 'columns', action: () => moveKanbanItem(item.id, 'doing', null) },
+          { label: t.kanbanDone, icon: 'columns', action: () => { moveKanbanItem(item.id, 'done', null); handleSetStatus(item.id, 'read') } },
           { label: '---', action: () => {} },
           { label: t.kanbanSetDueDate, icon: 'pin', action: () => setDueDateTarget(item.id) },
           ...(dueDates.get(item.id) ? [{ label: t.kanbanClearDueDate, icon: 'close' as const, action: () => setDueDate(item.id, undefined) }] : []),
@@ -589,7 +614,7 @@ export default function App() {
           <button key={g.id} className={`sg-tab ${g.id === nav.activeTabId ? 'sg-tab--active' : ''} ${dragState.dropTabId === g.id && dragState.draggingId !== g.id ? 'sg-tab--drop-target' : ''} ${dragState.draggingId === g.id ? 'sg-tab--dragging' : ''}`} role="tab" aria-selected={g.id === nav.activeTabId} title={String(idx + 1)} onClick={() => handleSelectTab(g.id)} onContextMenu={(e) => handleTabContext(g, e)} onDoubleClick={() => { setRenamingTabId(g.id); setRenameValue(g.title) }} {...getTabHandlers(g.id)}>
             {renamingTabId === g.id ? (
               <input className="sg-tab__rename" value={renameValue} onChange={(e) => setRenameValue(e.target.value)} onBlur={handleRenameSubmit} onKeyDown={(e) => { if (isComposing(e)) return; if (e.key === 'Enter') handleRenameSubmit(); if (e.key === 'Escape') setRenamingTabId(null) }} autoFocus onClick={(e) => e.stopPropagation()} />
-            ) : (<><span className="sg-tab__shortcut">{idx + 1}</span>{g.title}<span className="sg-tab__count">{countAll(g)}</span></>)}
+            ) : (<><span className="sg-tab__shortcut">{idx + 1}</span>{g.id === '__ungrouped__' ? t.uncategorized : g.title}<span className="sg-tab__count">{countAll(g)}</span></>)}
           </button>
         ))}
         {creatingGroup === 'tab' ? (
@@ -761,14 +786,16 @@ export default function App() {
               <div className="sg-empty"><div className="sg-empty__icon"><Icon name="pin" size={48} /></div><p className="sg-empty__text sg-preline">{t.emptyFolder}</p></div>
             ) : (
               <>
-                {/* ルート直下のブックマーク */}
-                {nav.currentFolder.items.length > 0 && (
+                {/* タブ直下のブックマーク: サブフォルダがある場合は折りたためる「未分類」セクションにまとめる */}
+                {uncategorizedGroup ? (
+                  <FolderSection key={UNCATEGORIZED_ID} group={uncategorizedGroup} depth={0} virtual {...folderSectionProps} />
+                ) : nav.currentFolder.items.length > 0 ? (
                   <div className={gridClass}>
                     {applyFiltersAndSort(nav.currentFolder.items).map((item) => (
                       <BookmarkCard key={item.id} item={item} onContextMenu={handleBookmarkContext} dragHandlers={getDragHandlers(item.id, 'bookmark')} isDragging={dragState.draggingId === item.id} isDropTarget={dragState.dropTargetId === item.id} dropMode={dragState.dropTargetId === item.id && dragState.dropMode !== 'into' ? dragState.dropMode : null} t={t} locale={settings.locale} isSelected={selectedIds.has(item.id)} onToggleSelect={toggleSelect} tags={allMeta[item.id]?.tags} status={allMeta[item.id]?.status} ogp={allMeta[item.id]?.ogp} onOpen={(id) => handleSetStatus(id, 'read')} />
                     ))}
                   </div>
-                )}
+                ) : null}
 
                 {/* フォルダをアコーディオンセクションとして表示 */}
                 {nav.currentFolder.children.map((child) => (
@@ -817,6 +844,7 @@ export default function App() {
         { target: '.sg-tab--add', title: t.addBookmark('Ctrl'), description: t.tourAdd },
         { target: '.sg-btn--icon:last-child', title: t.settings, description: t.tourSettings },
       ]} onComplete={handleCompleteTour} t={t} />)}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} dismissLabel={t.toastDismiss} />
     </>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -253,8 +253,9 @@ export default function App() {
     [updateSettings],
   )
 
+  // light → dark → system → light の3値循環（systemに到達できない不具合を修正）
   const handleToggleTheme = useCallback(
-    () => updateSettings((prev) => ({ theme: prev.theme === 'dark' ? 'light' : prev.theme === 'light' ? 'dark' : 'dark' })),
+    () => updateSettings((prev) => ({ theme: prev.theme === 'light' ? 'dark' : prev.theme === 'dark' ? 'system' : 'light' })),
     [updateSettings],
   )
 
@@ -638,7 +639,8 @@ export default function App() {
   // --- Render ---
   if (loading || !loaded) return <div className="sg-loading">{t.loading}</div>
 
-  if (showWelcome && groups.length === 0) {
+  // 初回起動時は既存ブックマークの有無に関わらずウェルカム画面を表示（skip/startでonboarded記録）
+  if (showWelcome) {
     return (
       <div className="sg-welcome">
         <div className="sg-welcome__logo"><Icon name="grid" size={48} /></div>

--- a/src/components/FolderSection.tsx
+++ b/src/components/FolderSection.tsx
@@ -13,6 +13,8 @@ import type { Messages } from '../i18n'
 interface Props {
   group: SyncGridGroup
   depth: number
+  /** 仮想フォルダ（未分類など）: ドラッグ・改名・フォルダメニューを無効化し、折りたたみのみ許可 */
+  virtual?: boolean
   collapsedIds: Set<string>
   onToggleCollapse: (id: string) => void
   gridClass: string
@@ -35,6 +37,7 @@ interface Props {
 export const FolderSection = memo(function FolderSection({
   group,
   depth,
+  virtual = false,
   collapsedIds,
   onToggleCollapse,
   gridClass,
@@ -74,9 +77,9 @@ export const FolderSection = memo(function FolderSection({
         className={`sg-section__header ${isDropTarget ? 'sg-section__header--drop-target' : ''} ${isDropBefore ? 'sg-section__header--drop-before' : ''} ${isDropAfter ? 'sg-section__header--drop-after' : ''}`}
         role="button"
         tabIndex={0}
-        draggable
-        onDragStart={folderDragHandlers.onDragStart}
-        onDragEnd={folderDragHandlers.onDragEnd}
+        draggable={!virtual}
+        onDragStart={virtual ? undefined : folderDragHandlers.onDragStart}
+        onDragEnd={virtual ? undefined : folderDragHandlers.onDragEnd}
         onClick={() => {
           if (!isRenaming) onToggleCollapse(group.id)
         }}
@@ -88,20 +91,20 @@ export const FolderSection = memo(function FolderSection({
             onToggleCollapse(group.id)
           }
         }}
-        onDoubleClick={(e) => {
+        onDoubleClick={virtual ? undefined : (e) => {
           e.stopPropagation()
           setEditValue(group.title)
           onStartRename(group.id)
         }}
-        onContextMenu={(e) => {
+        onContextMenu={virtual ? undefined : (e) => {
           e.preventDefault()
           onFolderContext(group, e.clientX, e.clientY)
         }}
         aria-expanded={!collapsed}
-        onDragOver={folderDragHandlers.onDragOver}
-        onDragEnter={folderDragHandlers.onDragEnter}
-        onDragLeave={folderDragHandlers.onDragLeave}
-        onDrop={folderDragHandlers.onDrop}
+        onDragOver={virtual ? undefined : folderDragHandlers.onDragOver}
+        onDragEnter={virtual ? undefined : folderDragHandlers.onDragEnter}
+        onDragLeave={virtual ? undefined : folderDragHandlers.onDragLeave}
+        onDrop={virtual ? undefined : folderDragHandlers.onDrop}
       >
         <span className={`sg-section__chevron ${collapsed ? 'sg-section__chevron--collapsed' : ''}`}>
           <Icon name="chevron-down" size={14} />
@@ -125,16 +128,18 @@ export const FolderSection = memo(function FolderSection({
           <span className="sg-section__title">{group.title}</span>
         )}
         <span className="sg-section__count">{t.items(totalItems)}</span>
-        <button
-          className="sg-section__menu"
-          onClick={(e) => {
-            e.stopPropagation()
-            onFolderContext(group, e.clientX, e.clientY)
-          }}
-          aria-label={t.menu}
-        >
-          <Icon name="more" size={14} />
-        </button>
+        {!virtual && (
+          <button
+            className="sg-section__menu"
+            onClick={(e) => {
+              e.stopPropagation()
+              onFolderContext(group, e.clientX, e.clientY)
+            }}
+            aria-label={t.menu}
+          >
+            <Icon name="more" size={14} />
+          </button>
+        )}
       </div>
 
       {!collapsed && (

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -135,11 +135,18 @@ export const KanbanBoard = memo(function KanbanBoard({
       const rect = e.currentTarget.getBoundingClientRect()
       const relY = (e.clientY - rect.top) / rect.height
       const columnItems = kanbanColumns[targetColumn]
-      // before: ターゲットの直前 / after: ターゲットの次のカードの直前（末尾なら null）
-      const beforeId =
-        relY < 0.5
-          ? targetBookmarkId
-          : columnItems[targetIndex + 1]?.id ?? null
+      // before: ターゲットの直前。after: ターゲット以降でドラッグ対象自身を除いた最初のカードの直前
+      // （対象自身をアンカーにすると moveInKanban で除外され末尾送りになるため必ずスキップ）
+      let beforeId: string | null = targetBookmarkId
+      if (relY >= 0.5) {
+        beforeId = null
+        for (let i = targetIndex + 1; i < columnItems.length; i++) {
+          if (columnItems[i].id !== data.bookmarkId) {
+            beforeId = columnItems[i].id
+            break
+          }
+        }
+      }
 
       onMoveItem(data.bookmarkId, targetColumn, beforeId)
       if (targetColumn === 'done' && onMarkRead) onMarkRead(data.bookmarkId)

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -9,7 +9,7 @@ interface Props {
   allMeta: Record<string, BookmarkMeta>
   dueDates: Map<string, number>
   locale: string
-  onMoveItem: (bookmarkId: string, toColumn: KanbanColumn, toOrder: number) => void
+  onMoveItem: (bookmarkId: string, toColumn: KanbanColumn, beforeBookmarkId: string | null) => void
   onContextMenu: (item: SyncGridItem, x: number, y: number) => void
   onOpen: (id: string) => void
   onMarkRead?: (id: string) => void
@@ -134,9 +134,14 @@ export const KanbanBoard = memo(function KanbanBoard({
 
       const rect = e.currentTarget.getBoundingClientRect()
       const relY = (e.clientY - rect.top) / rect.height
-      const order = relY < 0.5 ? targetIndex : targetIndex + 1
+      const columnItems = kanbanColumns[targetColumn]
+      // before: ターゲットの直前 / after: ターゲットの次のカードの直前（末尾なら null）
+      const beforeId =
+        relY < 0.5
+          ? targetBookmarkId
+          : columnItems[targetIndex + 1]?.id ?? null
 
-      onMoveItem(data.bookmarkId, targetColumn, order)
+      onMoveItem(data.bookmarkId, targetColumn, beforeId)
       if (targetColumn === 'done' && onMarkRead) onMarkRead(data.bookmarkId)
       resetDrag()
     },
@@ -172,12 +177,25 @@ export const KanbanBoard = memo(function KanbanBoard({
       const data = dragDataRef.current
       if (!data) return
 
-      const order = kanbanColumns[column].length
-      onMoveItem(data.bookmarkId, column, order)
+      // カード外（gap/padding/空エリア）へのドロップ:
+      // カーソル位置に最も近いカードを検出し、その直前に挿入する（なければ末尾）
+      const cards = e.currentTarget.querySelectorAll<HTMLElement>('.sg-kanban-card[data-card-id]')
+      let beforeId: string | null = null
+      for (const el of cards) {
+        const id = el.dataset.cardId
+        if (!id || id === data.bookmarkId) continue
+        const rect = el.getBoundingClientRect()
+        if (e.clientY < rect.top + rect.height / 2) {
+          beforeId = id
+          break
+        }
+      }
+
+      onMoveItem(data.bookmarkId, column, beforeId)
       if (column === 'done' && onMarkRead) onMarkRead(data.bookmarkId)
       resetDrag()
     },
-    [kanbanColumns, onMoveItem, onMarkRead, resetDrag],
+    [onMoveItem, onMarkRead, resetDrag],
   )
 
   if (totalItems === 0) {

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -92,6 +92,7 @@ export const KanbanCard = memo(function KanbanCard({
   return (
     <div
       className={cls}
+      data-card-id={item.id}
       onClick={handleClick}
       onContextMenu={handleContext}
       draggable
@@ -108,6 +109,7 @@ export const KanbanCard = memo(function KanbanCard({
         width={16}
         height={16}
         loading="lazy"
+        draggable={false}
       />
       <div className="sg-kanban-card__body">
         <span className="sg-kanban-card__title">

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -7,7 +7,7 @@ import type { SyncGridSettings, SyncGridGroup, AIProvider } from '../types'
 import { OPENAI_MODELS, GEMINI_MODELS } from '../types'
 import type { Messages } from '../i18n'
 import type { Locale } from '../i18n'
-import { exportData, downloadExport, readFileAsText, validateImport, importToBookmarks } from '../utils/dataTransfer'
+import { exportData, downloadExport, readFileAsText, validateImport, importToBookmarks, importKanban } from '../utils/dataTransfer'
 import {
   isSyncSupported,
   pickSyncFolder,
@@ -18,7 +18,7 @@ import {
   testSyncConnection,
 } from '../utils/localSync'
 import { testAiConnection } from '../utils/ai'
-import { hasTitleFetchPermission, requestTitleFetchPermission } from '../utils/permissions'
+import { hasTitleFetchPermission, requestTitleFetchPermission, hasAiPermission, requestAiPermission } from '../utils/permissions'
 
 interface Props {
   settings: SyncGridSettings
@@ -84,6 +84,7 @@ export function SettingsPanel({ settings, groups, t, onUpdateSettings, onClose, 
               return
             }
             await importToBookmarks(validated.data)
+            await importKanban(validated.kanban)
             setImportStatus('success')
             setTimeout(() => location.reload(), 1500)
           } catch {
@@ -140,6 +141,17 @@ export function SettingsPanel({ settings, groups, t, onUpdateSettings, onClose, 
   const handleAiTest = useCallback(async () => {
     setAiTestStatus('testing')
     setAiTestError('')
+    // AIホスト権限を確保（未付与ならこのユーザージェスチャー中にリクエスト）
+    if (!(await hasAiPermission(settings.ai.provider))) {
+      const granted = await requestAiPermission(settings.ai.provider)
+      if (!granted) {
+        setAiTestStatus('error')
+        setAiTestError(t.aiPermissionDenied)
+        clearTimeout(aiTestTimerRef.current)
+        aiTestTimerRef.current = setTimeout(() => setAiTestStatus('idle'), 4000)
+        return
+      }
+    }
     const result = await testAiConnection(settings.ai)
     if (result.ok) {
       setAiTestStatus('ok')
@@ -149,7 +161,7 @@ export function SettingsPanel({ settings, groups, t, onUpdateSettings, onClose, 
     }
     clearTimeout(aiTestTimerRef.current)
     aiTestTimerRef.current = setTimeout(() => setAiTestStatus('idle'), 4000)
-  }, [settings.ai])
+  }, [settings.ai, t])
 
   // --- Sync Connection Test ---
   const handleSyncTest = useCallback(async () => {

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,39 @@
+import { memo } from 'react'
+import { Icon, type IconName } from './Icon'
+import type { ToastItem, ToastType } from '../hooks/useToast'
+
+interface Props {
+  toasts: ToastItem[]
+  onDismiss: (id: number) => void
+  dismissLabel: string
+}
+
+const ICON_BY_TYPE: Record<ToastType, IconName> = {
+  info: 'help-circle',
+  success: 'check-circle',
+  error: 'x-circle',
+  warning: 'warning',
+}
+
+/** 画面右下に積み重なるトースト通知の表示コンテナ */
+export const ToastContainer = memo(function ToastContainer({ toasts, onDismiss, dismissLabel }: Props) {
+  if (toasts.length === 0) return null
+
+  return (
+    <div className="sg-toasts" role="status" aria-live="polite">
+      {toasts.map((toast) => (
+        <div key={toast.id} className={`sg-toast sg-toast--${toast.type}`}>
+          <Icon name={ICON_BY_TYPE[toast.type]} size={16} className="sg-toast__icon" />
+          <span className="sg-toast__message">{toast.message}</span>
+          <button
+            className="sg-toast__close"
+            onClick={() => onDismiss(toast.id)}
+            aria-label={dismissLabel}
+          >
+            <Icon name="close" size={14} />
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+})

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -176,8 +176,8 @@ export function TopBar({ query, onQueryChange, theme, onToggleTheme, onOpenSetti
           <Icon name="refresh" size={14} className={ogpSpinning ? 'sg-icon--spin' : ''} />
           <span>OGP</span>
         </button>
-        <button className="sg-btn--icon" onClick={onToggleTheme} title={t.toggleTheme}>
-          <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={16} />
+        <button className="sg-btn--icon" onClick={onToggleTheme} title={`${t.toggleTheme}: ${theme}`}>
+          <Icon name={theme === 'light' ? 'sun' : 'moon'} size={16} />
         </button>
         <button className="sg-btn--icon" onClick={onOpenShortcuts} title={t.shortcuts}>
           <Icon name="keyboard" size={16} />

--- a/src/hooks/useKanban.ts
+++ b/src/hooks/useKanban.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import type { SyncGridGroup, SyncGridItem, KanbanColumn, KanbanState } from '../types'
 import {
   loadKanban,
@@ -10,9 +10,21 @@ import {
 } from '../utils/kanban'
 import { flattenGroups } from '../utils/bookmarks'
 
-export function useKanban(groups: SyncGridGroup[]) {
+interface UseKanbanOptions {
+  /** 保存失敗時に呼ばれる（トースト表示など） */
+  onError?: () => void
+}
+
+export function useKanban(groups: SyncGridGroup[], options: UseKanbanOptions = {}) {
+  const { onError } = options
   const [kanbanState, setKanbanState] = useState<KanbanState>({ items: [] })
   const [now, setNow] = useState(() => Date.now())
+
+  // 最新の onError を ref 経由で参照（コールバックの依存を安定させる）
+  const onErrorRef = useRef(onError)
+  useEffect(() => {
+    onErrorRef.current = onError
+  }, [onError])
 
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 60_000)
@@ -47,10 +59,10 @@ export function useKanban(groups: SyncGridGroup[]) {
     cleanupKanban(new Set(urlMap.keys())).then(setKanbanState)
   }, [urlMap])
 
-  // 他端末からの同期変更を検知してUIに反映
+  // 他端末（sync）・同一端末の別タブ（local）からの変更を検知してUIに反映
   useEffect(() => {
     const handleChange = (changes: Record<string, chrome.storage.StorageChange>, areaName: string) => {
-      if (areaName === 'sync' && changes.syncgrid_kanban?.newValue) {
+      if ((areaName === 'sync' || areaName === 'local') && changes.syncgrid_kanban?.newValue) {
         setKanbanState(changes.syncgrid_kanban.newValue as KanbanState)
       }
     }
@@ -84,44 +96,57 @@ export function useKanban(groups: SyncGridGroup[]) {
     [kanbanState, idToUrl],
   )
 
+  // storage 書き込みを実行し、成功時に state 反映・失敗時にロールバック（再読込）＋通知する
+  const runMutation = useCallback(async (fn: () => Promise<KanbanState>) => {
+    try {
+      const state = await fn()
+      setKanbanState(state)
+    } catch {
+      // local 保存に失敗（quota 超過など）: 永続化された状態へ巻き戻す
+      onErrorRef.current?.()
+      try {
+        setKanbanState(await loadKanban())
+      } catch {
+        // 読み込みも失敗した場合は現状維持
+      }
+    }
+  }, [])
+
   const addToKanban = useCallback(
     async (bookmarkId: string, column: KanbanColumn = 'todo') => {
       const url = idToUrl.get(bookmarkId)
       if (!url) return
-      const state = await addToKanbanStorage(url, column)
-      setKanbanState(state)
+      await runMutation(() => addToKanbanStorage(url, column))
     },
-    [idToUrl],
+    [idToUrl, runMutation],
   )
 
   const removeFromKanban = useCallback(
     async (bookmarkId: string) => {
       const url = idToUrl.get(bookmarkId)
       if (!url) return
-      const state = await removeFromKanbanStorage(url)
-      setKanbanState(state)
+      await runMutation(() => removeFromKanbanStorage(url))
     },
-    [idToUrl],
+    [idToUrl, runMutation],
   )
 
   const moveItem = useCallback(
-    async (bookmarkId: string, toColumn: KanbanColumn, toOrder: number) => {
+    async (bookmarkId: string, toColumn: KanbanColumn, beforeBookmarkId: string | null) => {
       const url = idToUrl.get(bookmarkId)
       if (!url) return
-      const state = await moveInKanbanStorage(url, toColumn, toOrder)
-      setKanbanState(state)
+      const beforeUrl = beforeBookmarkId ? idToUrl.get(beforeBookmarkId) ?? null : null
+      await runMutation(() => moveInKanbanStorage(url, toColumn, beforeUrl))
     },
-    [idToUrl],
+    [idToUrl, runMutation],
   )
 
   const setDueDate = useCallback(
     async (bookmarkId: string, dueDate: number | undefined) => {
       const url = idToUrl.get(bookmarkId)
       if (!url) return
-      const state = await setDueDateInKanban(url, dueDate)
-      setKanbanState(state)
+      await runMutation(() => setDueDateInKanban(url, dueDate))
     },
-    [idToUrl],
+    [idToUrl, runMutation],
   )
 
   // 期限情報のマップ（bookmarkId → dueDate）

--- a/src/hooks/useMetadata.ts
+++ b/src/hooks/useMetadata.ts
@@ -4,7 +4,7 @@
  */
 import { useState, useEffect, useCallback, useRef } from 'react'
 import type { SyncGridGroup, BookmarkMeta, ReadStatus, SyncGridItem, OgpData } from '../types'
-import { loadAllMeta, saveMeta } from '../utils/storage'
+import { loadAllMeta, saveMeta, pruneOrphanMeta } from '../utils/storage'
 import { fetchOgp } from '../utils/fetchTitle'
 import { flattenGroups } from '../utils/bookmarks'
 
@@ -13,9 +13,25 @@ const OGP_CACHE_TTL = 24 * 60 * 60 * 1000 // 24h
 export function useMetadata(groups: SyncGridGroup[]) {
   const [allMeta, setAllMeta] = useState<Record<string, BookmarkMeta>>({})
   const fetchingRef = useRef<Set<string>>(new Set())
+  const prunedRef = useRef(false)
 
   useEffect(() => {
     loadAllMeta().then(setAllMeta)
+  }, [groups])
+
+  // 起動時に一度だけ、現存しないブックマークの孤立メタを掃除（storage.local肥大化対策）。
+  // groupsが空の一時状態では実行しない（有効メタの誤削除を防ぐ）
+  useEffect(() => {
+    if (prunedRef.current) return
+    const validIds = new Set<string>()
+    for (const g of flattenGroups(groups)) {
+      for (const item of g.items) validIds.add(item.id)
+    }
+    if (validIds.size === 0) return
+    prunedRef.current = true
+    pruneOrphanMeta(validIds).then((removed) => {
+      if (removed > 0) loadAllMeta().then(setAllMeta)
+    })
   }, [groups])
 
   // バックグラウンドOGPフェッチ — キャッシュ切れ or 未取得のアイテムを自動取得

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,40 @@
+import { useState, useCallback, useRef } from 'react'
+
+/** トーストの種別 */
+export type ToastType = 'info' | 'success' | 'error' | 'warning'
+
+/** 表示中のトースト */
+export interface ToastItem {
+  id: number
+  message: string
+  type: ToastType
+}
+
+const DEFAULT_DURATION = 4000
+
+/**
+ * 画面右下に短時間表示する通知（トースト）を管理するフック。
+ * 操作の成否をユーザーへ非侵襲的に伝える用途。
+ */
+export function useToast() {
+  const [toasts, setToasts] = useState<ToastItem[]>([])
+  const idRef = useRef(0)
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id))
+  }, [])
+
+  const showToast = useCallback(
+    (message: string, type: ToastType = 'info', duration = DEFAULT_DURATION) => {
+      const id = ++idRef.current
+      setToasts((prev) => [...prev, { id, message, type }])
+      if (duration > 0) {
+        setTimeout(() => dismiss(id), duration)
+      }
+      return id
+    },
+    [dismiss],
+  )
+
+  return { toasts, showToast, dismiss }
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -241,4 +241,7 @@ export const en = {
   uncategorized: 'Uncategorized',
   // Single delete confirmation
   confirmDeleteBookmark: (name: string) => `Delete "${name}"? It will be moved to the trash.`,
+  bookmarkDeleted: 'Moved to trash',
+  // AI permission
+  aiPermissionDenied: 'Access to the AI API is required. Grant it to connect.',
 } as const

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -233,4 +233,12 @@ export const en = {
   helpRefExportDesc: 'Back up and restore bookmark data as JSON files from Settings',
   helpRefSync: 'Local sync',
   helpRefSyncDesc: 'Select a local folder synced with a cloud drive (Google Drive, OneDrive, etc.) for auto backup',
+  // Toast / error notifications
+  toastDismiss: 'Dismiss notification',
+  kanbanSaveError: 'Failed to save the Kanban board (storage limit may have been reached)',
+  actionFailed: 'Something went wrong. Please try again.',
+  // Uncategorized folder
+  uncategorized: 'Uncategorized',
+  // Single delete confirmation
+  confirmDeleteBookmark: (name: string) => `Delete "${name}"? It will be moved to the trash.`,
 } as const

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -259,4 +259,12 @@ export const ja = {
   helpRefExportDesc: '設定画面からブックマークデータをJSONファイルとしてバックアップ・復元',
   helpRefSync: 'ローカル同期',
   helpRefSyncDesc: 'クラウドドライブ（Google Drive, OneDrive等）と同期されたローカルフォルダを選択して自動バックアップ',
+  // Toast / エラー通知
+  toastDismiss: '通知を閉じる',
+  kanbanSaveError: 'カンバンの保存に失敗しました（容量制限の可能性があります）',
+  actionFailed: '操作に失敗しました。もう一度お試しください。',
+  // 未分類フォルダ
+  uncategorized: '未分類',
+  // 単体削除の確認
+  confirmDeleteBookmark: (name: string) => `「${name}」を削除しますか？削除したブックマークはゴミ箱に移動します。`,
 } as const

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -267,4 +267,7 @@ export const ja = {
   uncategorized: '未分類',
   // 単体削除の確認
   confirmDeleteBookmark: (name: string) => `「${name}」を削除しますか？削除したブックマークはゴミ箱に移動します。`,
+  bookmarkDeleted: 'ゴミ箱に移動しました',
+  // AI権限
+  aiPermissionDenied: 'AI APIへのアクセス権限が必要です。許可すると接続できます。',
 } as const

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2399,16 +2399,18 @@ button {
 }
 
 .sg-kanban-card--drop-before {
-  box-shadow: 0 -2px 0 0 var(--sg-accent);
+  box-shadow: 0 -3px 0 0 var(--sg-accent);
 }
 
 .sg-kanban-card--drop-after {
-  box-shadow: 0 2px 0 0 var(--sg-accent);
+  box-shadow: 0 3px 0 0 var(--sg-accent);
 }
 
 .sg-kanban-card__favicon {
   flex-shrink: 0;
   border-radius: 4px;
+  /* 既定でドラッグ可能な img がカード左端のドラッグ開始を奪うのを防ぐ */
+  pointer-events: none;
 }
 
 .sg-kanban-card__body {
@@ -2417,6 +2419,8 @@ button {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  /* カード面全体を確実にドラッグ対象にする（メニューボタンは別途操作可能） */
+  pointer-events: none;
 }
 
 .sg-kanban-card__title {
@@ -2535,4 +2539,79 @@ button {
     grid-template-columns: 1fr;
     overflow-y: auto;
   }
+}
+
+/* --- Toast 通知 --- */
+.sg-toasts {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 600;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: min(360px, calc(100vw - 40px));
+  pointer-events: none;
+}
+
+.sg-toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: var(--sg-radius-sm);
+  background: var(--sg-bg-card);
+  border: 1px solid var(--sg-border);
+  box-shadow: var(--sg-shadow-modal);
+  color: var(--sg-text);
+  font-size: 13px;
+  line-height: 1.4;
+  pointer-events: auto;
+  animation: sg-toast-in 200ms ease;
+}
+
+@keyframes sg-toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sg-toast { animation: none; }
+}
+
+.sg-toast__icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.sg-toast--error { border-left: 3px solid var(--sg-danger); }
+.sg-toast--error .sg-toast__icon { color: var(--sg-danger); }
+.sg-toast--success { border-left: 3px solid var(--sg-success); }
+.sg-toast--success .sg-toast__icon { color: var(--sg-success); }
+.sg-toast--warning { border-left: 3px solid var(--sg-accent); }
+.sg-toast--warning .sg-toast__icon { color: var(--sg-accent); }
+.sg-toast--info .sg-toast__icon { color: var(--sg-text-secondary); }
+
+.sg-toast__message {
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.sg-toast__close {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  background: transparent;
+  color: var(--sg-text-tertiary);
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.sg-toast__close:hover {
+  color: var(--sg-text);
+  background: var(--sg-bg-card-hover);
 }

--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -11,6 +11,7 @@
 
 import type { AISettings } from '../types'
 import { fetchPageTitle } from './fetchTitle'
+import { ensureAiPermission } from './permissions'
 
 /** Test AI API connection by calling a lightweight endpoint */
 export async function testAiConnection(settings: AISettings): Promise<{ ok: boolean; error?: string }> {
@@ -152,6 +153,7 @@ export async function suggestCategories(
 /** Call OpenAI Chat Completions API */
 async function callOpenAI(prompt: string, apiKey: string, model: string, maxTokens: number = 100): Promise<string> {
   if (!apiKey) throw new Error('OpenAI API key not set')
+  await ensureAiPermission('openai')
 
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -188,6 +190,7 @@ async function callOpenAI(prompt: string, apiKey: string, model: string, maxToke
 /** Call Gemini generateContent API */
 async function callGemini(prompt: string, apiKey: string, model: string, maxTokens: number = 100): Promise<string> {
   if (!apiKey) throw new Error('Gemini API key not set')
+  await ensureAiPermission('gemini')
 
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`
 

--- a/src/utils/chromeMock.ts
+++ b/src/utils/chromeMock.ts
@@ -196,7 +196,45 @@ if (!IS_EXTENSION) {
   const onMoved = mockEvent()
 
   // --- Storage mock ---
-  const storageData: Record<string, unknown> = {}
+  const storageOnChanged = mockEvent()
+  const storageLocal: Record<string, unknown> = {}
+  const storageSync: Record<string, unknown> = {}
+
+  function makeStorageArea(data: Record<string, unknown>, areaName: string) {
+    return {
+      get: (keys: string | string[] | null) => {
+        if (keys === null) return Promise.resolve({ ...data })
+        const keyList = typeof keys === 'string' ? [keys] : keys
+        const result: Record<string, unknown> = {}
+        for (const k of keyList) {
+          if (k in data) result[k] = data[k]
+        }
+        return Promise.resolve(result)
+      },
+      set: (items: Record<string, unknown>) => {
+        const changes: Record<string, { oldValue?: unknown; newValue?: unknown }> = {}
+        for (const [k, v] of Object.entries(items)) {
+          changes[k] = { oldValue: data[k], newValue: v }
+        }
+        Object.assign(data, items)
+        storageOnChanged.fire(changes, areaName)
+        return Promise.resolve()
+      },
+      remove: (keys: string | string[]) => {
+        const keyList = typeof keys === 'string' ? [keys] : keys
+        const changes: Record<string, { oldValue?: unknown }> = {}
+        for (const k of keyList) {
+          if (k in data) {
+            changes[k] = { oldValue: data[k] }
+            delete data[k]
+          }
+        }
+        storageOnChanged.fire(changes, areaName)
+        return Promise.resolve()
+      },
+      getBytesInUse: () => Promise.resolve(0),
+    }
+  }
 
   // --- Mount mocks ---
   const g = globalThis as unknown as { chrome: typeof chrome }
@@ -285,20 +323,11 @@ if (!IS_EXTENSION) {
       onMoved,
     },
     storage: {
-      local: {
-        get: (keys: string | string[] | null) => {
-          if (keys === null) return Promise.resolve({ ...storageData })
-          const keyList = typeof keys === 'string' ? [keys] : keys
-          const result: Record<string, unknown> = {}
-          for (const k of keyList) {
-            if (k in storageData) result[k] = storageData[k]
-          }
-          return Promise.resolve(result)
-        },
-        set: (items: Record<string, unknown>) => {
-          Object.assign(storageData, items)
-          return Promise.resolve()
-        },
+      local: makeStorageArea(storageLocal, 'local'),
+      sync: makeStorageArea(storageSync, 'sync'),
+      onChanged: {
+        addListener: storageOnChanged.addListener,
+        removeListener: storageOnChanged.removeListener,
       },
     },
     permissions: {

--- a/src/utils/dataTransfer.ts
+++ b/src/utils/dataTransfer.ts
@@ -9,7 +9,7 @@
 
 import type { SyncGridGroup, SyncGridExport, SyncGridExportGroup, KanbanState } from '../types'
 import { SYNCGRID_ROOT } from '../types'
-import { loadKanban } from './kanban'
+import { loadKanban, saveKanban } from './kanban'
 
 // ===== EXPORT =====
 
@@ -209,6 +209,12 @@ async function restoreGroups(groups: SyncGridExportGroup[], parentId: string): P
     }
     await restoreGroups(group.children, folder.id)
   }
+}
+
+/** インポートしたカンバン状態を保存（存在する場合のみ） */
+export async function importKanban(kanban: KanbanState | undefined): Promise<void> {
+  if (!kanban || kanban.items.length === 0) return
+  await saveKanban(kanban)
 }
 
 export function readFileAsText(file: File): Promise<string> {

--- a/src/utils/kanban.ts
+++ b/src/utils/kanban.ts
@@ -4,30 +4,84 @@ const STORAGE_KEY = 'syncgrid_kanban'
 
 const EMPTY_STATE: KanbanState = { items: [] }
 
-export async function loadKanban(): Promise<KanbanState> {
-  const storage = globalThis.chrome?.storage?.sync
-  if (!storage?.get) return { ...EMPTY_STATE }
-  const result = await storage.get(STORAGE_KEY)
-  const stored = result[STORAGE_KEY]
-  if (!stored || typeof stored !== 'object' || !Array.isArray((stored as KanbanState).items)) {
-    return { ...EMPTY_STATE }
-  }
-  // マイグレーション: 旧形式（bookmarkId）→ 新形式（url）
-  const raw = stored as { items: Array<Record<string, unknown>> }
-  const hasOld = raw.items.some((i) => 'bookmarkId' in i && !('url' in i))
-  if (hasOld) {
-    raw.items = raw.items.filter((i) => 'url' in i && typeof i.url === 'string')
-    const cleaned = { items: raw.items } as unknown as KanbanState
-    saveKanban(cleaned)
-    return cleaned
-  }
-  return stored as KanbanState
+/** 保存結果。synced=false は sync ミラーが失敗（quota等）した場合。local保存は成功している */
+export interface SaveResult {
+  synced: boolean
 }
 
-export async function saveKanban(state: KanbanState): Promise<void> {
-  const storage = globalThis.chrome?.storage?.sync
-  if (!storage?.set) return
-  await storage.set({ [STORAGE_KEY]: state })
+function isValidState(value: unknown): value is KanbanState {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    Array.isArray((value as KanbanState).items)
+  )
+}
+
+/**
+ * 旧形式（bookmarkId のみ）→ 新形式（url）へマイグレーション。
+ * url を持たないアイテムは破棄する。変換が発生した場合は再保存する。
+ */
+function migrate(stored: KanbanState): { state: KanbanState; changed: boolean } {
+  const raw = stored as unknown as { items: Array<Record<string, unknown>> }
+  const hasOld = raw.items.some((i) => 'bookmarkId' in i && !('url' in i))
+  if (!hasOld) return { state: stored, changed: false }
+  const items = raw.items.filter((i) => 'url' in i && typeof i.url === 'string')
+  return { state: { items } as unknown as KanbanState, changed: true }
+}
+
+/**
+ * カンバン状態を読み込む。
+ * 主保存は chrome.storage.local。local に無ければ sync ミラーから復元する
+ * （新デバイスでの初回起動など）。
+ */
+export async function loadKanban(): Promise<KanbanState> {
+  const local = globalThis.chrome?.storage?.local
+  const sync = globalThis.chrome?.storage?.sync
+
+  let stored: unknown
+  if (local?.get) {
+    const result = await local.get(STORAGE_KEY)
+    stored = result[STORAGE_KEY]
+  }
+  // local に無ければ sync から復元
+  if (!isValidState(stored) && sync?.get) {
+    const result = await sync.get(STORAGE_KEY)
+    stored = result[STORAGE_KEY]
+  }
+
+  if (!isValidState(stored)) return { ...EMPTY_STATE }
+
+  const { state, changed } = migrate(stored)
+  if (changed) {
+    // マイグレーション結果を永続化（成否は問わない）
+    saveKanban(state).catch(() => {})
+  }
+  return state
+}
+
+/**
+ * カンバン状態を保存する。
+ * local を主保存として確実に書き込み（失敗時は throw）、
+ * sync へはベストエフォートでミラーする（quota 超過等は握りつぶし synced=false を返す）。
+ */
+export async function saveKanban(state: KanbanState): Promise<SaveResult> {
+  const local = globalThis.chrome?.storage?.local
+  if (local?.set) {
+    // 主保存。失敗（QUOTA_BYTES 超過など）は呼び出し側へ伝播させる
+    await local.set({ [STORAGE_KEY]: state })
+  }
+
+  const sync = globalThis.chrome?.storage?.sync
+  if (sync?.set) {
+    try {
+      await sync.set({ [STORAGE_KEY]: state })
+      return { synced: true }
+    } catch {
+      // sync は 8KB/item・120回/分 の制限で失敗しうる。local には保存済みなので実害は同期のみ
+      return { synced: false }
+    }
+  }
+  return { synced: false }
 }
 
 export async function addToKanban(url: string, column: KanbanColumn = 'todo'): Promise<KanbanState> {
@@ -48,36 +102,39 @@ export async function removeFromKanban(url: string): Promise<KanbanState> {
   return state
 }
 
+/**
+ * カンバンアイテムを移動する。
+ * 挿入位置は「beforeUrl のカードの直前」で指定する（beforeUrl=null なら列末尾）。
+ * ドラッグ対象を除いた並びに対してアンカー解決するため、index ずれ（off-by-one）が起きない。
+ */
 export async function moveInKanban(
   url: string,
   toColumn: KanbanColumn,
-  toOrder: number,
+  beforeUrl: string | null,
 ): Promise<KanbanState> {
   const state = await loadKanban()
   const item = state.items.find((i) => i.url === url)
   if (!item) return state
 
   const fromColumn = item.column
+  item.column = toColumn
 
-  if (fromColumn === toColumn) {
-    const colItems = state.items
-      .filter((i) => i.column === toColumn && i.url !== url)
+  // 移動元の列を詰め直す（別列へ移った場合）
+  if (fromColumn !== toColumn) {
+    state.items
+      .filter((i) => i.column === fromColumn)
       .sort((a, b) => a.order - b.order)
-    colItems.splice(toOrder, 0, item)
-    colItems.forEach((ci, idx) => { ci.order = idx })
-  } else {
-    const fromItems = state.items
-      .filter((i) => i.column === fromColumn && i.url !== url)
-      .sort((a, b) => a.order - b.order)
-    fromItems.forEach((ci, idx) => { ci.order = idx })
-
-    const toItems = state.items
-      .filter((i) => i.column === toColumn)
-      .sort((a, b) => a.order - b.order)
-    item.column = toColumn
-    toItems.splice(toOrder, 0, item)
-    toItems.forEach((ci, idx) => { ci.order = idx })
+      .forEach((ci, idx) => { ci.order = idx })
   }
+
+  // 移動先の列: ドラッグ対象を除いた並びにアンカー挿入
+  const colItems = state.items
+    .filter((i) => i.column === toColumn && i.url !== url)
+    .sort((a, b) => a.order - b.order)
+  const anchorIdx = beforeUrl ? colItems.findIndex((i) => i.url === beforeUrl) : -1
+  const insertAt = anchorIdx >= 0 ? anchorIdx : colItems.length
+  colItems.splice(insertAt, 0, item)
+  colItems.forEach((ci, idx) => { ci.order = idx })
 
   await saveKanban(state)
   return state

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -24,3 +24,41 @@ export async function requestTitleFetchPermission(): Promise<boolean> {
     return false
   }
 }
+
+/** AIプロバイダ別のAPIエンドポイントorigin */
+const AI_PROVIDER_ORIGINS: Record<string, string> = {
+  openai: 'https://api.openai.com/*',
+  gemini: 'https://generativelanguage.googleapis.com/*',
+}
+
+/** 指定AIプロバイダのホスト権限が付与済みか確認 */
+export async function hasAiPermission(provider: string): Promise<boolean> {
+  const origin = AI_PROVIDER_ORIGINS[provider]
+  if (!origin) return false
+  try {
+    return await chrome.permissions.contains({ origins: [origin] })
+  } catch {
+    return false
+  }
+}
+
+/** 指定AIプロバイダのホスト権限をリクエスト（ユーザージェスチャー必須） */
+export async function requestAiPermission(provider: string): Promise<boolean> {
+  const origin = AI_PROVIDER_ORIGINS[provider]
+  if (!origin) return false
+  try {
+    return await chrome.permissions.request({ origins: [origin] })
+  } catch {
+    return false
+  }
+}
+
+/**
+ * AIホスト権限を確保する（未付与ならリクエスト）。
+ * ユーザージェスチャー起点のAI機能から呼ぶこと。
+ * 付与できなくても false を返すだけで、後続のfetch失敗として扱われる。
+ */
+export async function ensureAiPermission(provider: string): Promise<boolean> {
+  if (await hasAiPermission(provider)) return true
+  return requestAiPermission(provider)
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -84,6 +84,26 @@ export async function saveMeta(bookmarkId: string, meta: BookmarkMeta): Promise<
 }
 
 /**
+ * 現存しないブックマークの孤立メタデータ（meta_*）を削除する。
+ * @param validBookmarkIds 現存するブックマークIDの集合
+ * @returns 削除した孤立メタの件数
+ */
+export async function pruneOrphanMeta(validBookmarkIds: Set<string>): Promise<number> {
+  const all = await chrome.storage.local.get(null)
+  const orphanKeys: string[] = []
+  for (const key of Object.keys(all)) {
+    if (key.startsWith(META_PREFIX)) {
+      const id = key.slice(META_PREFIX.length)
+      if (!validBookmarkIds.has(id)) orphanKeys.push(key)
+    }
+  }
+  if (orphanKeys.length > 0) {
+    await chrome.storage.local.remove(orphanKeys)
+  }
+  return orphanKeys.length
+}
+
+/**
  * 全メタデータを一括読み込み
  */
 export async function loadAllMeta(): Promise<Record<string, BookmarkMeta>> {


### PR DESCRIPTION
## 概要
Chrome Web Store公開前の安定化。ユーザー報告の3件（カンバン非永続・DnD不安定・未分類カードが折りたためない）を根本修正し、公開ブロッカー（削除経路・権限・エラー処理）と品質改善を実施。

## 主な変更
### ユーザー報告の3件
- **カンバン永続化**: 主保存を`storage.local`に変更（8KB制限のsyncでlocal状態に巻き戻る問題を解消）、syncはベストエフォートミラー。保存失敗時はロールバック＋エラートースト
- **DnD**: favicon `draggable={false}`（左上で反応しない主因）、ドロップ位置をアンカー方式に変えoff-by-one解消、gap/padding最近傍判定、同列自己アンカーの末尾送り修正
- **未分類フォルダ**: タブ直下の素カードを折りたためる仮想フォルダとして表示、i18n化

### 公開ブロッカー
- 単体削除をゴミ箱経由＋確認に統一（復元可能化）
- AI用host_permissionsをoptional化（審査対策、ジェスチャーで個別リクエスト）
- 主要CRUDハンドラのtry/catch＋トースト、インポートでKanban復元

### 品質改善
- 孤立メタの起動時GC、テーマ3値循環、初回ウェルカム表示、期限モーダルのa11y

## 検証
tsc -b / ESLint / テスト79件 / 本番ビルド すべて通過。マルチエージェントレビューで検出した同列DnDバグ1件を修正済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * トースト通知を追加し、失敗時のメッセージや完了通知が画面右下に表示されるようになりました。
  * カンバンの並び替えがより直感的になり、カードの前後にドラッグして挿入できます。
  * 「未分類」を仮想フォルダとして表示し、見た目を整理しました。

* **バグ修正**
  * テーマ切り替えの挙動を修正しました。
  * 保存・削除・移動などの操作で、失敗時に内容が分かりやすく通知されるようになりました。
  * 不要なデータやキャッシュが残りにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->