### PR TITLE
refactor: レビュー指摘のクリーンアップ（重複集約・AI権限の適正化）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,8 +38,11 @@ import {
   deleteGroup,
   getRootId,
   flattenGroups,
+  getAllItems,
+  findItemById,
   countAll,
   findGroupById,
+  UNGROUPED_ID,
 } from './utils/bookmarks'
 import { addToTrash } from './utils/trash'
 import type { SyncGridItem, SyncGridGroup, LayoutMode, SortMode } from './types'
@@ -48,7 +51,11 @@ import { pullKanbanFromSync } from './utils/localSync'
 
 import './styles/global.css'
 
-/** タブ直下の未分類ブックマークをまとめる仮想フォルダのID */
+/**
+ * フォルダ内の未分類ブックマークをまとめる仮想フォルダセクションのID。
+ * タブレベルの未分類グループ（bookmarks.ts の UNGROUPED_ID）とは別スコープ:
+ * こちらは「タブを開いた中で、サブフォルダに属さない直下ブックマーク」を折りたたむ用途。
+ */
 const UNCATEGORIZED_ID = '__uncategorized_virtual__'
 
 export default function App() {
@@ -139,7 +146,7 @@ export default function App() {
 
       const { hasTitleFetchPermission } = await import('./utils/permissions')
       const granted = await hasTitleFetchPermission()
-      const allItems = flattenGroups(groups).flatMap((g) => g.items)
+      const allItems = getAllItems(groups)
       const total = allItems.length
 
       if (!granted && total >= 5) {
@@ -313,60 +320,65 @@ export default function App() {
   }, [nav.activeTabId, refresh])
 
   // --- Group/Folder CRUD ---
+  // 失敗時にエラートーストを出す共通ラッパ（各CRUDハンドラの try/catch を集約）
+  const runWithErrorToast = useCallback(
+    async (fn: () => Promise<void>) => {
+      try {
+        await fn()
+      } catch {
+        showToast(t.actionFailed, 'error')
+      }
+    },
+    [showToast, t],
+  )
+
   const handleAddGroup = useCallback(() => { setCreatingGroup('tab'); setNewGroupName('') }, [])
 
   const handleCreateGroup = useCallback(async () => {
     const name = newGroupName.trim()
     if (!name) { setCreatingGroup(false); return }
-    try {
+    await runWithErrorToast(async () => {
       await createGroup(name, await getRootId())
       setCreatingGroup(false)
       setNewGroupName('')
       await refresh()
-    } catch {
-      showToast(t.actionFailed, 'error')
-    }
-  }, [newGroupName, refresh, showToast, t])
+    })
+  }, [newGroupName, refresh, runWithErrorToast])
 
   const handleCreateSubfolder = useCallback(async () => {
     const name = newGroupName.trim()
     if (!name) { setCreatingGroup(false); return }
-    try {
+    await runWithErrorToast(async () => {
       await createGroup(name, nav.currentFolder?.id || (await getRootId()))
       setCreatingGroup(false)
       setNewGroupName('')
       await refresh()
-    } catch {
-      showToast(t.actionFailed, 'error')
-    }
-  }, [newGroupName, nav.currentFolder, refresh, showToast, t])
+    })
+  }, [newGroupName, nav.currentFolder, refresh, runWithErrorToast])
 
   const handleAddBookmark = useCallback(
     async (url: string, title: string) => {
       if (!nav.currentFolder) return
-      try {
-        await addBookmark(nav.currentFolder.id, title, url)
+      const folderId = nav.currentFolder.id
+      await runWithErrorToast(async () => {
+        await addBookmark(folderId, title, url)
         setShowAddForm(false)
         await refresh()
-      } catch {
-        showToast(t.actionFailed, 'error')
-      }
+      })
     },
-    [nav.currentFolder, refresh, showToast, t],
+    [nav.currentFolder, refresh, runWithErrorToast],
   )
 
   const handleSaveBookmark = useCallback(
     async (id: string, title: string, url: string, tags: string[]) => {
-      try {
+      await runWithErrorToast(async () => {
         await updateBookmark(id, { title, url })
         await handleSaveMeta(id, tags)
         setEditItem(null)
         await refresh()
-      } catch {
-        showToast(t.actionFailed, 'error')
-      }
+      })
     },
-    [refresh, handleSaveMeta, showToast, t],
+    [refresh, handleSaveMeta, runWithErrorToast],
   )
 
   // ブックマークをゴミ箱経由で削除する共通処理（確認ダイアログ＋トースト＋復元可能）
@@ -403,9 +415,7 @@ export default function App() {
   // 編集モーダルからの削除（id受け取り→itemを解決）
   const handleDeleteBookmark = useCallback(
     (id: string) => {
-      const item = editItem?.id === id
-        ? editItem
-        : flattenGroups(groups).flatMap((g) => g.items).find((i) => i.id === id)
+      const item = editItem?.id === id ? editItem : findItemById(groups, id)
       if (item) requestDeleteBookmark(item)
     },
     [editItem, groups, requestDeleteBookmark],
@@ -414,29 +424,25 @@ export default function App() {
   const handleFolderRename = useCallback(
     async (id: string, name: string) => {
       const trimmed = name.trim()
-      try {
+      await runWithErrorToast(async () => {
         if (trimmed) await renameGroup(id, trimmed)
         setRenamingFolderId(null)
         await refresh()
-      } catch {
-        showToast(t.actionFailed, 'error')
-      }
+      })
     },
-    [refresh, showToast, t],
+    [refresh, runWithErrorToast],
   )
 
   const handleRenameSubmit = useCallback(async () => {
     if (!renamingTabId) return
     const name = renameValue.trim()
-    try {
+    await runWithErrorToast(async () => {
       if (name) await renameGroup(renamingTabId, name)
       setRenamingTabId(null)
       setRenameValue('')
       await refresh()
-    } catch {
-      showToast(t.actionFailed, 'error')
-    }
-  }, [renamingTabId, renameValue, refresh, showToast, t])
+    })
+  }, [renamingTabId, renameValue, refresh, runWithErrorToast])
 
   // --- Context menus ---
   const handleBookmarkContext = useCallback(
@@ -673,13 +679,13 @@ export default function App() {
         <button className={`sg-tab ${nav.activeTabId === '__all__' ? 'sg-tab--active' : ''}`} role="tab" aria-selected={nav.activeTabId === '__all__'} onClick={() => handleSelectTab('__all__')} title="0">
           <span className="sg-tab__shortcut">0</span>
           {t.allBookmarks}
-          <span className="sg-tab__count">{flattenGroups(groups).reduce((sum, g) => sum + g.items.length, 0)}</span>
+          <span className="sg-tab__count">{getAllItems(groups).length}</span>
         </button>
         {groups.map((g, idx) => (
           <button key={g.id} className={`sg-tab ${g.id === nav.activeTabId ? 'sg-tab--active' : ''} ${dragState.dropTabId === g.id && dragState.draggingId !== g.id ? 'sg-tab--drop-target' : ''} ${dragState.draggingId === g.id ? 'sg-tab--dragging' : ''}`} role="tab" aria-selected={g.id === nav.activeTabId} title={String(idx + 1)} onClick={() => handleSelectTab(g.id)} onContextMenu={(e) => handleTabContext(g, e)} onDoubleClick={() => { setRenamingTabId(g.id); setRenameValue(g.title) }} {...getTabHandlers(g.id)}>
             {renamingTabId === g.id ? (
               <input className="sg-tab__rename" value={renameValue} onChange={(e) => setRenameValue(e.target.value)} onBlur={handleRenameSubmit} onKeyDown={(e) => { if (isComposing(e)) return; if (e.key === 'Enter') handleRenameSubmit(); if (e.key === 'Escape') setRenamingTabId(null) }} autoFocus onClick={(e) => e.stopPropagation()} />
-            ) : (<><span className="sg-tab__shortcut">{idx + 1}</span>{g.id === '__ungrouped__' ? t.uncategorized : g.title}<span className="sg-tab__count">{countAll(g)}</span></>)}
+            ) : (<><span className="sg-tab__shortcut">{idx + 1}</span>{g.id === UNGROUPED_ID ? t.uncategorized : g.title}<span className="sg-tab__count">{countAll(g)}</span></>)}
           </button>
         ))}
         {creatingGroup === 'tab' ? (

--- a/src/components/AddBookmarkForm.tsx
+++ b/src/components/AddBookmarkForm.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import type { Messages } from '../i18n'
 import type { AISettings } from '../types'
 import { generateTitle } from '../utils/ai'
+import { ensureAiPermission } from '../utils/permissions'
 import { fetchPageTitle, fetchPageTitleWithPermission } from '../utils/fetchTitle'
 import { Icon } from './Icon'
 import { isModKey, isComposing, MOD_LABEL, ENTER_LABEL } from '../utils/keyboard'
@@ -107,6 +108,12 @@ export function AddBookmarkForm({ onAdd, onCancel, t, aiSettings }: Props) {
     setAiLoading(true)
     setAiError('')
     try {
+      // AIホスト権限をこのユーザージェスチャー中に確保（未付与ならリクエスト）
+      if (!(await ensureAiPermission(aiSettings.provider))) {
+        setAiError(t.aiPermissionDenied)
+        setTimeout(() => setAiError(''), 3000)
+        return
+      }
       const generated = await generateTitle(finalUrl, aiSettings)
       setTitle(generated)
     } catch {

--- a/src/components/AiCategorizeModal.tsx
+++ b/src/components/AiCategorizeModal.tsx
@@ -5,6 +5,7 @@ import { useState, useCallback } from 'react'
 import { Icon } from './Icon'
 import { useFocusTrap } from '../hooks/useFocusTrap'
 import { suggestCategories } from '../utils/ai'
+import { ensureAiPermission } from '../utils/permissions'
 import { createGroup } from '../utils/bookmarks'
 import type { SyncGridItem, SyncGridGroup, AISettings } from '../types'
 import type { Messages } from '../i18n'
@@ -26,12 +27,16 @@ export function AiCategorizeModal({ items, parentFolder, aiSettings, onDone, onC
   const [categories, setCategories] = useState<Record<string, string[]>>({})
   const [error, setError] = useState('')
 
-  // 初回ロード
+  // 初回ロード（モーダルを開いたジェスチャー直後にAIホスト権限を確保）
   useState(() => {
-    suggestCategories(
-      items.map((i) => ({ title: i.title, url: i.url })),
-      aiSettings,
-    )
+    ensureAiPermission(aiSettings.provider)
+      .then((granted) => {
+        if (!granted) throw new Error('AI host permission not granted')
+        return suggestCategories(
+          items.map((i) => ({ title: i.title, url: i.url })),
+          aiSettings,
+        )
+      })
       .then((result) => {
         setCategories(result)
         setPhase('result')

--- a/src/components/EditBookmarkModal.tsx
+++ b/src/components/EditBookmarkModal.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { useFocusTrap } from '../hooks/useFocusTrap'
 import { refetchTitle } from '../utils/fetchTitle'
 import { generateTags } from '../utils/ai'
+import { ensureAiPermission } from '../utils/permissions'
 import { isComposing } from '../utils/keyboard'
 import { Icon } from './Icon'
 import type { SyncGridItem, AISettings } from '../types'
@@ -66,6 +67,8 @@ export function EditBookmarkModal({ item, onSave, onDelete, onClose, t, initialT
     if (aiSettings.provider === 'none') return
     setAiTagLoading(true)
     try {
+      // AIホスト権限をこのユーザージェスチャー中に確保（未付与ならリクエスト）
+      if (!(await ensureAiPermission(aiSettings.provider))) return
       const generated = await generateTags(url.trim(), title.trim(), aiSettings)
       // 既存タグと重複しないものを追加
       setTags((prev) => [...new Set([...prev, ...generated])])

--- a/src/hooks/useDragReorder.ts
+++ b/src/hooks/useDragReorder.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from 'react'
-import { getRootId } from '../utils/bookmarks'
+import { getRootId, UNGROUPED_ID } from '../utils/bookmarks'
 
 type DragItemType = 'bookmark' | 'folder' | 'tab'
 type DropMode = 'before' | 'after' | 'into' | null
@@ -243,7 +243,7 @@ export function useDragReorder(selectedIds?: Set<string>, onKanbanDrop?: (bookma
             }
           } else {
             // カード/フォルダ → タブへ移動（複数選択対応）
-            const targetId = tabId === '__ungrouped__' ? await getRootId() : tabId
+            const targetId = tabId === UNGROUPED_ID ? await getRootId() : tabId
             const idsToMove =
               selectedIds && selectedIds.size > 1 && selectedIds.has(data.id) ? [...selectedIds] : [data.id]
             for (const moveId of idsToMove) {

--- a/src/hooks/useMetadata.ts
+++ b/src/hooks/useMetadata.ts
@@ -29,8 +29,9 @@ export function useMetadata(groups: SyncGridGroup[]) {
     }
     if (validIds.size === 0) return
     prunedRef.current = true
-    pruneOrphanMeta(validIds).then((removed) => {
-      if (removed > 0) loadAllMeta().then(setAllMeta)
+    pruneOrphanMeta(validIds).then(({ removed, metas }) => {
+      // 走査ついでに得た生存メタで直接更新（追加のloadAllMeta不要）
+      if (removed > 0) setAllMeta(metas)
     })
   }, [groups])
 

--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -11,7 +11,6 @@
 
 import type { AISettings } from '../types'
 import { fetchPageTitle } from './fetchTitle'
-import { ensureAiPermission } from './permissions'
 
 /** Test AI API connection by calling a lightweight endpoint */
 export async function testAiConnection(settings: AISettings): Promise<{ ok: boolean; error?: string }> {
@@ -153,7 +152,6 @@ export async function suggestCategories(
 /** Call OpenAI Chat Completions API */
 async function callOpenAI(prompt: string, apiKey: string, model: string, maxTokens: number = 100): Promise<string> {
   if (!apiKey) throw new Error('OpenAI API key not set')
-  await ensureAiPermission('openai')
 
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -190,7 +188,6 @@ async function callOpenAI(prompt: string, apiKey: string, model: string, maxToke
 /** Call Gemini generateContent API */
 async function callGemini(prompt: string, apiKey: string, model: string, maxTokens: number = 100): Promise<string> {
   if (!apiKey) throw new Error('Gemini API key not set')
-  await ensureAiPermission('gemini')
 
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`
 

--- a/src/utils/bookmarks.ts
+++ b/src/utils/bookmarks.ts
@@ -1,5 +1,8 @@
 import { SYNCGRID_ROOT, type SyncGridGroup, type SyncGridItem } from '../types'
 
+/** タブレベルの未分類グループID（__SyncGrid__ルート直下の所属なしブックマークを集約） */
+export const UNGROUPED_ID = '__ungrouped__'
+
 /**
  * __SyncGrid__ ルートフォルダを取得（なければ作成）
  */
@@ -76,7 +79,7 @@ export async function loadGroups(): Promise<SyncGridGroup[]> {
 
   if (ungroupedItems.length > 0) {
     groups.push({
-      id: '__ungrouped__',
+      id: UNGROUPED_ID,
       title: '未分類',
       items: ungroupedItems,
       children: [],
@@ -194,6 +197,28 @@ export function flattenGroups(groups: SyncGridGroup[]): SyncGridGroup[] {
     result.push(...flattenGroups(group.children))
   }
   return result
+}
+
+/**
+ * 全グループ配下の全ブックマークアイテムを1次元配列で取得
+ */
+export function getAllItems(groups: SyncGridGroup[]): SyncGridItem[] {
+  const items: SyncGridItem[] = []
+  for (const group of flattenGroups(groups)) {
+    items.push(...group.items)
+  }
+  return items
+}
+
+/**
+ * ツリー全体からIDでブックマークアイテムを検索（中間配列を作らず走査）
+ */
+export function findItemById(groups: SyncGridGroup[], id: string): SyncGridItem | undefined {
+  for (const group of flattenGroups(groups)) {
+    const found = group.items.find((item) => item.id === id)
+    if (found) return found
+  }
+  return undefined
 }
 
 /** Chrome bookmark tree内のフォルダ情報 */

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -85,22 +85,30 @@ export async function saveMeta(bookmarkId: string, meta: BookmarkMeta): Promise<
 
 /**
  * 現存しないブックマークの孤立メタデータ（meta_*）を削除する。
+ * 走査ついでに生存メタを返すので、呼び出し側は追加の loadAllMeta が不要。
  * @param validBookmarkIds 現存するブックマークIDの集合
- * @returns 削除した孤立メタの件数
+ * @returns removed=削除件数、metas=生存メタのマップ
  */
-export async function pruneOrphanMeta(validBookmarkIds: Set<string>): Promise<number> {
+export async function pruneOrphanMeta(
+  validBookmarkIds: Set<string>,
+): Promise<{ removed: number; metas: Record<string, BookmarkMeta> }> {
   const all = await chrome.storage.local.get(null)
   const orphanKeys: string[] = []
-  for (const key of Object.keys(all)) {
+  const metas: Record<string, BookmarkMeta> = {}
+  for (const [key, value] of Object.entries(all)) {
     if (key.startsWith(META_PREFIX)) {
       const id = key.slice(META_PREFIX.length)
-      if (!validBookmarkIds.has(id)) orphanKeys.push(key)
+      if (validBookmarkIds.has(id)) {
+        metas[id] = value as BookmarkMeta
+      } else {
+        orphanKeys.push(key)
+      }
     }
   }
   if (orphanKeys.length > 0) {
     await chrome.storage.local.remove(orphanKeys)
   }
-  return orphanKeys.length
+  return { removed: orphanKeys.length, metas }
 }
 
 /**


### PR DESCRIPTION
## 概要
PR #10 のマルチエージェントレビューで挙がった非ブロッキング指摘を潰す。動作変更なし・リファクタ中心。

## 対応した指摘
- **重複走査の集約**: `findItemById` / `getAllItems` を bookmarks.ts に追加し、App.tsx の `flattenGroups(...).flatMap(g=>g.items)` 重複3箇所を置換
- **CRUDエラー処理の集約**: `runWithErrorToast` ラッパで6ハンドラの try/catch を一本化
- **起動時スキャン削減**: `pruneOrphanMeta` が生存メタを返すようにし、余分な `loadAllMeta` を排除
- **AI権限の適正化（altitude）**: 権限リクエストを ai.ts（fetch層）からジェスチャー起点（AddBookmarkForm/EditBookmarkModal/AiCategorizeModal/SettingsPanel）へ移動。ai.ts を権限非依存化し、非ジェスチャー経路での握り潰しを解消
- **sentinel ID整理**: `__ungrouped__` を `UNGROUPED_ID` 定数化、`__uncategorized_virtual__` との用途差をコメント明示

## 検証
tsc -b / ESLint / テスト79件 / 本番ビルド すべて通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AIによるタイトル生成・タグ生成・カテゴリ提案の前に権限確認が入るようになり、許可されない場合は適切なエラー表示で中断されます。

* **Bug Fixes**
  * ブックマーク件数や未分類タブの表示がより正確になりました。
  * フォルダ／タブの名前変更や削除時のエラー通知を統一し、失敗時の案内をわかりやすくしました。
  * 起動時の不要なメタデータを効率よく整理し、表示の整合性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->