### PR TITLE
fix: OpenAI新モデル対応とステータスフィルタ永続化

### DIFF
--- a/src/hooks/useFiltering.ts
+++ b/src/hooks/useFiltering.ts
@@ -1,10 +1,12 @@
 /**
  * 検索・フィルタリング・ソート・フラット表示
  */
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import type { SyncGridItem, SyncGridGroup, SortMode, ReadStatus, BookmarkMeta } from '../types'
 import { flattenGroups } from '../utils/bookmarks'
 import { getDomain } from '../utils/favicon'
+
+const FILTER_STATUS_KEY = 'syncgrid_filter_status'
 
 export function useFiltering(
   groups: SyncGridGroup[],
@@ -15,7 +17,21 @@ export function useFiltering(
   const [query, setQuery] = useState('')
   const [localQuery, setLocalQuery] = useState('')
   const [filterTag, setFilterTag] = useState<string | null>(null)
-  const [filterStatus, setFilterStatus] = useState<ReadStatus | null>(null)
+  // ステータスフィルタ（すべて/未読/後で読む/…）はタブを閉じても維持する（useCollapseと同じ方式で永続化）
+  const [filterStatus, setFilterStatusState] = useState<ReadStatus | null>(null)
+
+  useEffect(() => {
+    chrome.storage.local.get(FILTER_STATUS_KEY).then((result) => {
+      const stored = result[FILTER_STATUS_KEY] as ReadStatus | undefined
+      if (stored) setFilterStatusState(stored)
+    })
+  }, [])
+
+  const setFilterStatus = useCallback((status: ReadStatus | null) => {
+    setFilterStatusState(status)
+    if (status) chrome.storage.local.set({ [FILTER_STATUS_KEY]: status })
+    else chrome.storage.local.remove(FILTER_STATUS_KEY)
+  }, [])
   // グローバル検索（全ブックマーク横断）
   const searchResults = useMemo(() => {
     if (!query.trim()) return null

--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -169,8 +169,10 @@ async function callOpenAI(prompt: string, apiKey: string, model: string, maxToke
         },
         { role: 'user', content: prompt },
       ],
-      max_tokens: maxTokens,
-      temperature: 0.3,
+      // max_tokensは新しめのモデル(gpt-5系/o系)で拒否される。max_completion_tokensは全現行モデル対応。
+      // 推論系モデルは思考トークンもこの上限に含むため、小さすぎると本文が空になる。下限1024を確保
+      max_completion_tokens: Math.max(maxTokens, 1024),
+      // temperatureも同系モデルはデフォルト値以外を拒否するため指定しない
     }),
   })
 


### PR DESCRIPTION
## 概要

1. **AI分類/タイトル生成が新しめのOpenAIモデルで400エラー** — `max_tokens` は gpt-5系/o系で廃止されているため `max_completion_tokens` に変更。あわせて (a) 推論系モデルは思考トークンも上限に含み小さい上限だと本文が空になるため下限1024を確保、(b) デフォルト以外の `temperature` を拒否するモデルがあるため指定を撤廃。報告されたエラーはコード側で根絶し、ユーザーへの対処案内は不要になります。
2. **ステータスフィルタが永続化されない** — チップ(すべて/未読/後で読む/お気に入り/既読)の選択を `chrome.storage.local`(key: `syncgrid_filter_status`)に永続化。ソート(settings)と折りたたみ(syncgrid_collapsed)は既に永続化済みのため、未対応だったのはこの1点でした。検索語・タグフィルタは一時的な性質のため対象外。

## 検証

- テスト 79/79 pass、lint クリーン、ビルド成功
- 手動確認項目: フィルタを「未読」にして新規タブを開き直す → 「未読」が維持される / OpenAIキー設定済み環境でAI分類が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ステータスフィルタの選択内容が保存され、次回起動時に自動で復元されるようになりました。
* **改善**
  * 条件に応じてフィルタを解除した場合、保存内容も正しく消去されるようになりました。
  * AI生成時の応答上限が見直され、長めの結果を取得しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->