### PR TITLE
chore: 拡張IDを固定してクロスPC同期を可能にする

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,6 +4,7 @@
   "version": "2.0.0",
   "description": "__MSG_appDescription__",
   "default_locale": "en",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4RmWuYGSSOommGC5EYbjsNziPV/9KwApW5RFrGgPYUZOsJDpDGgdaNfSJfgvm69xu+ttC9R8lyAwEvB/dGRkvVzb3hi5BBjRs3bCnzhzXKtLz1MnhT+2akOU7o73C5+IuX/6z1UDKy4K2R40ce+egcuq0IcrB8iNuto2kX4bMeqCP1EvnL7ijscsiceennIrAHqfwdh9ODaLiDShc756lKBh+hoyRttXf/IfHWC90Cwn9CrI9jQ5K9t6pWi4it32vx4KdPGOVNWoF432866EOxaxVDnnLeEBJM0uX4s2tMlhlgi7wJZOjUqRV7M7Z5H26sPnagzti1BYJPS/u4539QIDAQAB",
   "chrome_url_overrides": {
     "newtab": "index.html"
   },


### PR DESCRIPTION
## 背景

Kanban同期のコードは正しい（同一端末内はE2Eで検証済み）が、**別PC間では同期しない**。原因は拡張機能の同期ストレージの仕様:

- `chrome.storage.sync` のデータは**拡張機能IDごとに名前空間が分離**される
- 開発者モード（unpacked）の拡張IDは**ロード先の絶対パスから導出**される
- → 2台のPCでパスが違えばIDが変わり、sync が繋がらない

## 変更

manifest に公開鍵 `key` を追加し、拡張IDを `jofmnlfjbffoiiaideeajdfgnaeeeaij` に固定。これで全PCで同一IDになり、同一Googleアカウント + Chrome同期ON の複数PCでKanbanが同期する。

## 検証

- `npm run e2e:smoke`: 拡張IDが固定値 `jofmnlfjbffoiiaideeajdfgnaeeeaij` になったことを確認（従来はパス由来の別ID）。全チェックPASS
- ビルド・テスト128/128 pass

## 注意（Web Store公開時）

ストア公開時はストア側がIDを再割り当てするため、この dev key は公開時に再調整が必要（ストアのkeyに差し替えるか削除）。dev期間のsyncデータは公開版（別ID）には引き継がれない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)