### PR TITLE
表示時の無効なfavicon URLを修正

### DIFF
--- a/src/components/BookmarkCard.tsx
+++ b/src/components/BookmarkCard.tsx
@@ -39,6 +39,7 @@ export const BookmarkCard = memo(function BookmarkCard({ item, onContextMenu, dr
   const leaveTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
   const domain = getDomain(item.url)
   const initial = domain.charAt(0).toUpperCase()
+  const faviconUrl = getFaviconUrl(item.url, 64)
 
   // スクロール時にプレビュー消す
   useEffect(() => {
@@ -111,11 +112,11 @@ export const BookmarkCard = memo(function BookmarkCard({ item, onContextMenu, dr
           </div>
         ) : (
           <div className="sg-card__icon">
-            {imgFailed ? (
+            {imgFailed || !faviconUrl ? (
               <div className="sg-favicon sg-favicon--lg">{initial}</div>
             ) : (
               <img
-                src={getFaviconUrl(item.url, 64)}
+                src={faviconUrl}
                 alt=""
                 width={48}
                 height={48}

--- a/src/utils/__tests__/favicon.test.ts
+++ b/src/utils/__tests__/favicon.test.ts
@@ -39,4 +39,15 @@ describe('getFaviconUrl', () => {
     const result = getFaviconUrl('https://example.com')
     expect(result).toContain('size=32')
   })
+
+  it('returns empty string outside an extension context', () => {
+    const originalId = chrome.runtime.id
+    chrome.runtime.id = ''
+
+    try {
+      expect(getFaviconUrl('https://example.com')).toBe('')
+    } finally {
+      chrome.runtime.id = originalId
+    }
+  })
 })

--- a/src/utils/favicon.ts
+++ b/src/utils/favicon.ts
@@ -6,9 +6,13 @@
 export function getFaviconUrl(url: string, size: number = 32): string {
   try {
     const pageUrl = new URL(url).href
+    const extensionId = typeof chrome !== 'undefined' ? chrome.runtime?.id : undefined
+    // The favicon endpoint is only available inside the loaded extension.
+    // Avoid emitting an invalid chrome-extension:/// URL in Vite dev mode.
+    if (!extensionId) return ''
     // Chrome favicon2 API: キャッシュ済みファビコンを取得
     // show_fallback_monogram: ファビコンが無い場合にイニシャルアイコンを表示
-    return `chrome-extension://${chrome.runtime.id}/_favicon/?pageUrl=${encodeURIComponent(pageUrl)}&size=${size}`
+    return `chrome-extension://${extensionId}/_favicon/?pageUrl=${encodeURIComponent(pageUrl)}&size=${size}`
   } catch {
     // 不正なURLの場合は空文字（BookmarkCardのfallback UIが表示される）
     return ''


### PR DESCRIPTION
## 概要

Vite開発環境で無効な `chrome-extension:///` URL が生成され、favicon読み込み時に `ERR_FILE_NOT_FOUND` が発生して表示が崩れる問題を修正します。

## 変更内容

- 拡張機能コンテキスト外ではfavicon URLを生成せず、ブックマークの初期文字を表示
- favicon URLを一度だけ生成して再利用
- 拡張機能コンテキスト外の動作を回帰テストで追加

## 関連 Issue

N/A

## 確認事項

- [x] TypeScript型チェックが通る（`npm run build`）
- [x] ESLintエラーがない（`npm run lint`）
- [ ] テストが通る（`npm run test:run`）
- [x] i18n: ユーザー向け文字列の変更なし
- [x] 外部通信を追加していない（ゼロテレメトリ原則）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ブックマークのファビコンを事前に取得し、取得できない場合はドメインの頭文字を表示するよう改善しました。
  * 拡張機能外の環境で無効なファビコンURLが生成される問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->